### PR TITLE
Remove hint for using Yarn

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,6 @@ git clone https://github.com/micromata/http-fake-backend.git
 npm install
 ```
 
-*Hint: Use `yarn install` instead of `npm install` if you have installed [Yarn](https://yarnpkg.com/) … and yup, we have a lock file* :sparkling_heart:
-
-
 Or with help of [Yeoman](http://yeoman.io)
 
 ```bash


### PR DESCRIPTION
In my opinion this hint is deprecated with npm 5.3.X.
My Shell told me this after an install with npm:
"added 567 packages in 9.595s"

So i think you can use Yarn but there is noch downside with npm anymore.