### PR TITLE
feat: Add possibility to define custom response header

### DIFF
--- a/.env
+++ b/.env
@@ -11,3 +11,7 @@ TEST_PORT=9090
 # URL Prefix for the endpoints
 # eg. http://localhost:8081/api/foo
 API_PREFIX=/api
+
+# Custom response header
+#CUSTOM_HEADER_NAME=Authorization
+#CUSTOM_HEADER_VALUE=Bearer eyJhbGciOiJIUzUxMiJ9

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ npm start
 
 Just starts the server via node.
 
-## Configuring endpoints
+## Configure endpoints
 
 Each endpoint needs a configuration file in `/server/api/` to define routes, http method and the response.
 
@@ -236,7 +236,7 @@ The configuration object in Detail:
   * Optional
   * Every subroute of this endpoint will return a HTTP error with the given status code provided by [boom](https://github.com/hapijs/boom).
 
-## Configuration
+## Configure server
 
 The main config is handled via a file named `.env` with the following content:
 
@@ -254,6 +254,10 @@ TEST_PORT=9090
 # URL Prefix for the endpoints
 # eg. http://localhost:8081/api/foo
 API_PREFIX=/api
+
+# Custom response header
+#CUSTOM_HEADER_NAME=Authorization
+#CUSTOM_HEADER_VALUE=Bearer eyJhbGciOiJIUzUxMiJ9
 
 ```
 

--- a/manifest.js
+++ b/manifest.js
@@ -4,6 +4,7 @@ const Confidence = require('confidence');
 const Config = require('./config');
 const Fs = require('fs');
 const Path = require('path');
+const GetCustomResponseHeader = require('./server/api/setup/lib/getCustomResponseHeader');
 
 const criteria = {
     env: process.env.NODE_ENV
@@ -22,7 +23,8 @@ const manifest = {
                 security: true,
                 cors: {
                     origin: ['*'],
-                    credentials: true
+                    credentials: true,
+                    additionalExposedHeaders: [GetCustomResponseHeader(process.env).name]
                 }
             },
             router: {

--- a/server/api/setup/lib/getCustomResponseHeader.js
+++ b/server/api/setup/lib/getCustomResponseHeader.js
@@ -1,0 +1,9 @@
+'use strict';
+
+module.exports = function (env) {
+
+    return {
+        name: env.CUSTOM_HEADER_NAME || 'X-Powered-By',
+        value: env.CUSTOM_HEADER_VALUE || 'https://hapijs.com'
+    };
+};

--- a/server/api/setup/unsupportedMethods.js
+++ b/server/api/setup/unsupportedMethods.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const Boom = require('boom');
+const CustomResponseHeader = require('./lib/getCustomResponseHeader')(process.env);
 
 module.exports = function (settings, params, path) {
 
@@ -18,6 +19,7 @@ module.exports = function (settings, params, path) {
                 response = Boom.methodNotAllowed();
             }
 
+            response.output.headers[CustomResponseHeader.name] = CustomResponseHeader.value;
             return reply(response);
         }
     };

--- a/test/manifest.js
+++ b/test/manifest.js
@@ -22,4 +22,10 @@ lab.experiment('Manifest', () => {
         Code.expect(Manifest.meta('/')).to.match(/hapi server config used by glue to compose the server/i);
         done();
     });
+
+    lab.test('it gets the correct custom response header', (done) => {
+
+        Code.expect(Manifest.get('/').server.connections.routes.cors.additionalExposedHeaders).to.equal(['X-Powered-By']);
+        done();
+    });
 });

--- a/test/server/api/CustomResponseHeader.js
+++ b/test/server/api/CustomResponseHeader.js
@@ -1,0 +1,165 @@
+'use strict';
+
+const Lab = require('lab');
+const Code = require('code');
+const Config = require('../../../config');
+const Hapi = require('hapi');
+const SetupEndpoint = require('../../../server/api/setup/');
+const GetCustomResponseHeader = require('../../../server/api/setup/lib/getCustomResponseHeader');
+
+const apiUrlPrefix = Config.get('/apiUrlPrefix');
+
+const Endpoint = SetupEndpoint({
+    name: 'customResponseHeader',
+    urls: [
+        {
+            params: '/regularResponse',
+            requests: [
+                { response: '/test/server/api/fixtures/response.json' }
+            ]
+        },
+        {
+            params: '/fileResponse',
+            requests: [{
+                response: '/test/server/api/fixtures/example.pdf',
+                sendFile: true,
+                mimeType: 'application/pdf'
+            }]
+        },
+        {
+            params: '/boomError',
+            requests: [{ statusCode: 402 }]
+        }
+    ]
+});
+
+const lab = exports.lab = Lab.script();
+let request;
+let server;
+
+lab.beforeEach((done) => {
+
+    const plugins = [Endpoint];
+    server = new Hapi.Server();
+    server.connection({ port: Config.get('/port/web') });
+    server.register(plugins, (err) => {
+
+        if (err) {
+            return done(err);
+        }
+
+        done();
+    });
+});
+
+
+lab.experiment('Custom response header', () => {
+
+    lab.beforeEach((done) => {
+
+
+        done();
+    });
+
+    lab.test('should be read from .env file', (done) => {
+
+        const env = Object.assign({}, process.env);
+
+        env.CUSTOM_HEADER_NAME = 'Authorization';
+        env.CUSTOM_HEADER_VALUE = 'Bearer eyJhbGciOiJIUzUxMiJ9';
+
+        Code.expect(GetCustomResponseHeader(env)).to.equal({
+            name: 'Authorization',
+            value: 'Bearer eyJhbGciOiJIUzUxMiJ9'
+        });
+
+        done();
+    });
+
+    lab.test('should have a fallback if not defined in .env file', (done) => {
+
+
+        Code.expect(GetCustomResponseHeader(process.env)).to.equal({
+            name: 'X-Powered-By',
+            value: 'https://hapijs.com'
+        });
+
+        done();
+    });
+
+    lab.test('regular responses should have the defined response header', (done) => {
+
+        request = {
+            method: 'GET',
+            url: apiUrlPrefix + '/customResponseHeader/regularResponse'
+        };
+
+        server.inject(request, (response) => {
+
+            Code.expect(response.headers['x-powered-by']).to.equal('https://hapijs.com');
+
+            done();
+        });
+    });
+
+    lab.test('file responses should have the defined response header', (done) => {
+
+        request = {
+            method: 'GET',
+            url: apiUrlPrefix + '/customResponseHeader/fileResponse'
+        };
+
+        server.inject(request, (response) => {
+
+            Code.expect(response.headers['x-powered-by']).to.equal('https://hapijs.com');
+
+            done();
+        });
+    });
+
+    lab.test('boom errors should have the defined response header', (done) => {
+
+        request = {
+            method: 'GET',
+            url: apiUrlPrefix + '/customResponseHeader/boomError'
+        };
+
+        server.inject(request, (response) => {
+
+            Code.expect(response.headers['x-powered-by']).to.equal('https://hapijs.com');
+
+            done();
+        });
+    });
+
+    lab.test('unallowed methods of regular responses should have the defined response header', (done) => {
+
+        request = {
+            method: 'POST',
+            url: apiUrlPrefix + '/customResponseHeader/regularResponse'
+        };
+
+        server.inject(request, (response) => {
+
+            Code.expect(response.headers['x-powered-by']).to.equal('https://hapijs.com');
+
+            done();
+        });
+    });
+
+    lab.test('unallowed methods of boom errors should have the defined response header', (done) => {
+
+        request = {
+            method: 'POST',
+            url: apiUrlPrefix + '/customResponseHeader/boomError'
+        };
+
+        server.inject(request, (response) => {
+
+            Code.expect(response.headers['x-powered-by']).to.equal('https://hapijs.com');
+
+            done();
+        });
+    });
+
+});


### PR DESCRIPTION
Closes #10

This can be configured globally via the new setting in `.env`.